### PR TITLE
feat(brew): add Homebrew formula for macOS installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,27 @@ jobs:
             done
           done
 
+      - name: Create platform tarballs
+        run: |
+          TAG=${{ steps.get_tag.outputs.TAG }}
+          for os in linux darwin windows; do
+            for arch in amd64 arm64; do
+              ext=""
+              if [ "$os" = "windows" ]; then
+                ext=".exe"
+              fi
+              staging="aict-${TAG}-${os}-${arch}"
+              mkdir -p "$staging/completions"
+              cp "aict-${os}-${arch}${ext}" "$staging/aict${ext}"
+              cp "aict-mcp-${os}-${arch}${ext}" "$staging/aict-mcp${ext}"
+              cp completions/aict.bash "$staging/completions/"
+              cp completions/aict.zsh "$staging/completions/"
+              cp LICENSE "$staging/"
+              tar czf "releases/aict-${TAG}-${os}-${arch}.tar.gz" "$staging"
+              rm -rf "$staging"
+            done
+          done
+
       - name: Create checksums
         run: |
           cd releases
@@ -183,3 +204,20 @@ jobs:
           name: releases
           path: releases/
           retention-days: 30
+
+  # Update Homebrew tap formula on new releases
+  update-brew:
+    needs: [release]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update Homebrew formula
+        uses: mislav/bump-homebrew-formula-action@v3
+        with:
+          formula-name: aict
+          homebrew-tap: synseqack/homebrew-aict
+          download-url: https://github.com/synseqack/aict/releases/download/${{ github.ref_name }}/aict-${{ github.ref_name }}-darwin-arm64.tar.gz
+        env:
+          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/Formula/aict.rb
+++ b/Formula/aict.rb
@@ -1,0 +1,40 @@
+# typed: false
+# frozen_string_literal: true
+
+class Aict < Formula
+  desc "CLI tools with XML/JSON output for AI agents"
+  homepage "https://github.com/synseqack/aict"
+  version "1.0.3"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/synseqack/aict/releases/download/v#{version}/aict-v#{version}-darwin-arm64.tar.gz"
+      sha256 "PLACEHOLDER"
+    elsif Hardware::CPU.intel?
+      url "https://github.com/synseqack/aict/releases/download/v#{version}/aict-v#{version}-darwin-amd64.tar.gz"
+      sha256 "PLACEHOLDER"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/synseqack/aict/releases/download/v#{version}/aict-v#{version}-linux-arm64.tar.gz"
+      sha256 "PLACEHOLDER"
+    elsif Hardware::CPU.intel?
+      url "https://github.com/synseqack/aict/releases/download/v#{version}/aict-v#{version}-linux-amd64.tar.gz"
+      sha256 "PLACEHOLDER"
+    end
+  end
+
+  def install
+    bin.install "aict"
+    bin.install "aict-mcp"
+    bash_completion.install "completions/aict.bash" => "aict"
+    zsh_completion.install "completions/aict.zsh" => "_aict"
+  end
+
+  test do
+    assert_match "aict", shell_output("#{bin}/aict --help")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -31,12 +31,24 @@ Every field is labeled. Paths are absolute. Timestamps are Unix integers. Langua
 
 ## Install
 
+### Homebrew (macOS)
+
+```bash
+brew tap synseqack/aict
+brew install aict
+```
+
+This installs both `aict` and `aict-mcp` binaries, plus shell completions for bash and zsh.
+
+### Go Install
+
 ```
 go install github.com/synseqack/aict@latest
 go install github.com/synseqack/aict/cmd/mcp@latest
 ```
 
-Or build from source:
+### Build from Source
+
 ```
 git clone https://github.com/synseqack/aict
 cd aict


### PR DESCRIPTION
## Summary

Adds Homebrew tap support for easy macOS installation of `aict`. Closes #2.

## Changes

### Formula (`Formula/aict.rb`)
- Architecture-aware formula supporting both Apple Silicon (arm64) and Intel (amd64)
- Supports macOS and Linux via Homebrew/Linuxbrew
- Downloads pre-built platform-specific `.tar.gz` from GitHub Releases
- Installs both `aict` and `aict-mcp` binaries
- Installs bash and zsh shell completions

### CI (`ci.yml`)
- Release job now produces per-platform `.tar.gz` archives containing both binaries, completions, and LICENSE
- New `update-brew` job auto-updates the Homebrew tap formula on each tagged release using `mislav/bump-homebrew-formula-action`

### Docs (`README.md`)
- Added "Homebrew (macOS)" subsection under Install with `brew tap` / `brew install` instructions

## Checklist

- [x] Formula created: Supports both `aict` and `aict-mcp`
- [x] Binary distribution: Configured to pull pre-built Darwin binaries
- [x] Shell Completions: Logic added to the Formula to handle completion scripts
- [x] Automation: Added `ci.yml` job to keep the Formula updated on new tags
- [x] Docs: Installation instructions added to `README.md`

## Prerequisites (maintainer action required)

1. **Create tap repo**: `synseqack/homebrew-aict` must exist on GitHub with `Formula/aict.rb` from this PR
2. **Add secret**: Add `HOMEBREW_TAP_TOKEN` (a GitHub PAT with `repo` scope) to this repo's Settings → Secrets
3. **First release**: After merging, push a new tag to generate `.tar.gz` archives and update SHA256 placeholders in the formula
